### PR TITLE
Implement pagination for CP problems

### DIFF
--- a/src/app/admin/dashboard/page.jsx
+++ b/src/app/admin/dashboard/page.jsx
@@ -1235,6 +1235,9 @@ function EditEventsUI({ token, events, setReloadEvents }) {
 
 function CPProblemsSection() {
     const [problems, setProblems] = useState([]);
+	const [page, setPage] = useState(1);
+	const [totalPages, setTotalPages] = useState(1);
+	const PAGE_SIZE = 5;
     const [loading, setLoading] = useState(false);
     const [problemLink, setProblemLink] = useState("");
     const [posting, setPosting] = useState(false);
@@ -1243,25 +1246,26 @@ function CPProblemsSection() {
     const token = localStorage.getItem("token");
 
     // Fetch CP problems
-    useEffect(() => {
-        const fetchProblems = async () => {
-            setLoading(true);
-            try {
-                const res = await fetch("/api/cp/post-problem", {
-                    method: "GET"
-                });
-                if (!res.ok) throw new Error("Failed to fetch problems");
-                const data = await res.json();
-                setProblems(data.problems || []);
-            } catch (err) {
-                alert(err.message);
-            } finally {
-                setLoading(false);
-            }
-        };
+    const fetchProblems = async () => {
+        setLoading(true);
+        try {
+            const res = await fetch(`/api/cp/post-problem?page=${page}&limit=${PAGE_SIZE}`, {
+                method: "GET",
+            });
+            if (!res.ok) throw new Error("Failed to fetch problems");
+            const data = await res.json();
+            setTotalPages(data.totalPages || 1);
+            setProblems(data.problems || []);
+        } catch (err) {
+            alert(err.message);
+        } finally {
+            setLoading(false);
+        }
+    };
 
+    useEffect(() => {
         fetchProblems();
-    }, [token]);
+    }, [token, page]);
 
     const handleDelete = async (id) => {
         if (!confirm("Delete this problem?")) return;
@@ -1271,7 +1275,11 @@ function CPProblemsSection() {
                 method: "DELETE",
             });
             if (!res.ok) throw new Error("Failed to delete problem");
-            setProblems((prev) => prev.filter((prob) => prob._id !== id));
+            if (problems.length === 1 && page > 1) {
+                setPage((prev) => prev - 1);
+            } else {
+                await fetchProblems();
+            }
         } catch (err) {
             alert(err.message);
         } finally {
@@ -1294,8 +1302,8 @@ function CPProblemsSection() {
             });
             const data = await res.json();
             if (!res.ok) throw new Error(data.error || "Failed to post problem");
-            setProblems((prev) => [data.problem, ...prev]);
             setProblemLink("");
+            await fetchProblems();
             alert("Problem posted!");
         } catch (err) {
             alert(err.message);
@@ -1385,6 +1393,41 @@ function CPProblemsSection() {
                         </div>
                     </div>
                 ))}
+            </div>
+            <div style={{ display: "flex", alignItems: "center", gap: "1rem", marginTop: "1.5rem" }}>
+                <button
+                    onClick={() => setPage((prev) => Math.max(prev - 1, 1))}
+                    disabled={page === 1 || loading}
+                    style={{
+                        background: "#36d1c4",
+                        color: "white",
+                        border: "none",
+                        borderRadius: 4,
+                        padding: "0.5rem 1rem",
+                        cursor: page === 1 || loading ? "not-allowed" : "pointer",
+                        opacity: page === 1 || loading ? 0.7 : 1,
+                    }}
+                >
+                    Previous
+                </button>
+                <span>
+                    Page {page} of {totalPages}
+                </span>
+                <button
+                    onClick={() => setPage((prev) => Math.min(prev + 1, totalPages))}
+                    disabled={page >= totalPages || loading}
+                    style={{
+                        background: "#36d1c4",
+                        color: "white",
+                        border: "none",
+                        borderRadius: 4,
+                        padding: "0.5rem 1rem",
+                        cursor: page >= totalPages || loading ? "not-allowed" : "pointer",
+                        opacity: page >= totalPages || loading ? 0.7 : 1,
+                    }}
+                >
+                    Next
+                </button>
             </div>
 
             {/* Solution Dialog */}

--- a/src/app/api/cp/post-problem/route.js
+++ b/src/app/api/cp/post-problem/route.js
@@ -34,16 +34,61 @@ export async function POST(request) {
   }
 }
 
-export async function GET() {
+export async function GET(request) {
   try {
-    const problems = await CPProblem.find({}).sort({ postedAt: -1 });
+    const { searchParams } = new URL(request.url);
+
+    const parsedPage = Number.parseInt(searchParams.get("page") || "1", 10);
+    const parsedLimit = Number.parseInt(searchParams.get("limit") || "10", 10);
+
+    const currentPage = Number.isNaN(parsedPage)
+      ? 1
+      : Math.max(parsedPage, 1);
+
+    const pageSize = Number.isNaN(parsedLimit)
+      ? 10
+      : Math.min(Math.max(parsedLimit, 1), 50);
+
+    const skip = (currentPage - 1) * pageSize;
+
+    console.log("================================");
+    console.log("Request URL:", request.url);
+    console.log("Page Param:", searchParams.get("page"));
+    console.log("Limit Param:", searchParams.get("limit"));
+    console.log({
+      currentPage,
+      pageSize,
+      skip,
+    });
+
+    const totalProblems = await CPProblem.countDocuments();
+
+    const totalPages =
+      totalProblems === 0
+        ? 0
+        : Math.ceil(totalProblems / pageSize);
+
+    const problems = await CPProblem.find({})
+      .sort({ postedAt: -1 })
+      .skip(skip)
+      .limit(pageSize);
+
+    console.log(
+      "Returned Problems:",
+      problems.map((p) => p.problemId)
+    );
 
     return NextResponse.json({
       success: true,
       problems,
+      currentPage,
+      totalPages,
+      totalProblems,
+      pageSize,
     });
   } catch (error) {
     console.error("Error in GET route:", error);
+
     return NextResponse.json(
       { error: "Internal server error" },
       { status: 500 }

--- a/src/app/cp-gym/CpGymProfile.jsx
+++ b/src/app/cp-gym/CpGymProfile.jsx
@@ -24,6 +24,7 @@ const ActivityTooltip = ({ active, payload }) => {
 };
 
 const CpGymProfile = ({ codeforcesHandle }) => {
+  const PAGE_SIZE = 5;
   const [problemSolved, setProblemSolved] = useState(0);
   const [totalProblems, setTotalProblems] = useState(0);
   const [rankLeaderboard, setRankLeaderboard] = useState('NA');
@@ -101,14 +102,14 @@ const CpGymProfile = ({ codeforcesHandle }) => {
       
       try {
         const [problemsRes, solvedRes] = await Promise.all([
-          fetch('/api/cp/post-problem'),
+          fetch(`/api/cp/post-problem?page=1&limit=${PAGE_SIZE}`),
           fetch(`/api/problem-solve/get/${codeforcesHandle}`)
         ]);
 
         let total = 0;
         if (problemsRes.ok) {
           const problemsData = await problemsRes.json();
-          total = problemsData.problems?.length || 0;
+          total = problemsData.totalProblems || problemsData.problems?.length || 0;
           setTotalProblems(total);
         }
 

--- a/src/app/cp-gym/moderator/page.jsx
+++ b/src/app/cp-gym/moderator/page.jsx
@@ -7,6 +7,9 @@ import Loader from "@/ui-components/Loader1";
 
 function CPProblemsSection() {
     const [problems, setProblems] = useState([]);
+    const [page, setPage] = useState(1);
+    const [totalPages, setTotalPages] = useState(1);
+    const PAGE_SIZE = 5;
     const [loading, setLoading] = useState(false);
     const [problemLink, setProblemLink] = useState("");
     const [posting, setPosting] = useState(false);
@@ -25,29 +28,29 @@ function CPProblemsSection() {
     }, []);
 
     // Fetch CP problems
-    useEffect(() => {
+    const fetchProblems = async () => {
         if (!token) return;
 
-        const fetchProblems = async () => {
-            setLoading(true);
-            try {
-                const res = await fetch("/api/cp/post-problem", {
-                    method: "GET",
-                    headers: { authorization: "Bearer " + token },
-                });
-                if (!res.ok) throw new Error("Failed to fetch problems");
-                const data = await res.json();
-                setProblems(data.problems || []);
-                // console.log(data.problems);
-            } catch (err) {
-                alert(err.message);
-            } finally {
-                setLoading(false);
-            }
-        };
+        setLoading(true);
+        try {
+            const res = await fetch(`/api/cp/post-problem?page=${page}&limit=${PAGE_SIZE}`, {
+                method: "GET",
+                headers: { authorization: "Bearer " + token },
+            });
+            if (!res.ok) throw new Error("Failed to fetch problems");
+            const data = await res.json();
+            setTotalPages(data.totalPages || 1);
+            setProblems(data.problems || []);
+        } catch (err) {
+            alert(err.message);
+        } finally {
+            setLoading(false);
+        }
+    };
 
+    useEffect(() => {
         fetchProblems();
-    }, [token, role]);
+    }, [token, page]);
 
     const handleDelete = async (id) => {
         if (!confirm("Delete this problem?")) return;
@@ -58,7 +61,11 @@ function CPProblemsSection() {
                 headers: { authorization: "Bearer " + token },
             });
             if (!res.ok) throw new Error("Failed to delete problem");
-            setProblems((prev) => prev.filter((prob) => (prob._id || prob.id) !== id));
+            if (problems.length === 1 && page > 1) {
+                setPage((prev) => prev - 1);
+            } else {
+                await fetchProblems();
+            }
         } catch (err) {
             alert(err.message);
         } finally {
@@ -81,8 +88,8 @@ function CPProblemsSection() {
             });
             const data = await res.json();
             if (!res.ok) throw new Error(data.error || "Failed to post problem");
-            setProblems((prev) => [data.problem, ...prev]);
             setProblemLink("");
+            await fetchProblems();
             alert("Problem posted!");
         } catch (err) {
             alert(err.message);
@@ -311,6 +318,27 @@ function CPProblemsSection() {
                                 </div>
                             </div>
                         ))}
+                    </div>
+                    <div className="mt-8 flex flex-col sm:flex-row items-center justify-between gap-4 rounded-2xl border border-gray-800 bg-gray-900/50 p-4">
+                        <p className="text-sm font-medium text-gray-300">
+                            Page {page} of {totalPages}
+                        </p>
+                        <div className="flex items-center gap-3">
+                            <button
+                                onClick={() => setPage((prev) => Math.max(prev - 1, 1))}
+                                disabled={page === 1 || loading}
+                                className="px-5 py-2.5 border border-gray-700 text-gray-300 font-semibold rounded-2xl hover:bg-gray-800 transition-all duration-300 disabled:cursor-not-allowed disabled:opacity-50"
+                            >
+                                Previous
+                            </button>
+                            <button
+                                onClick={() => setPage((prev) => Math.min(prev + 1, totalPages))}
+                                disabled={page >= totalPages || loading}
+                                className="px-5 py-2.5 bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700 disabled:from-gray-600 disabled:to-gray-700 text-white font-semibold rounded-2xl transition-all duration-300 disabled:cursor-not-allowed disabled:opacity-50"
+                            >
+                                Next
+                            </button>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/app/cp-gym/page.jsx
+++ b/src/app/cp-gym/page.jsx
@@ -15,10 +15,18 @@ import CpGymProfile from '@/app/cp-gym/CpGymProfile';
 import { useRouter } from 'next/navigation';
 
 const CPGymPage = () => {
+    const PAGE_SIZE = 5;
     const [activeTab, setActiveTab] = useState('problems');
     const [problems, setProblems] = useState([]);
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState(null);
+    const [currentPage, setCurrentPage] = useState(1);
+    const [pagination, setPagination] = useState({
+        currentPage: 1,
+        totalPages: 0,
+        totalProblems: 0,
+        pageSize: PAGE_SIZE
+    });
     const [codeforcesHandle, setCodeforcesHandle] = useState('');
     const [leaderboardData, setLeaderboardData] = useState([]);
     const [isLeaderboardLoading, setIsLeaderboardLoading] = useState(true);
@@ -449,7 +457,8 @@ const CPGymPage = () => {
         const fetchProblems = async () => {
             try {
                 setIsLoading(true);
-                const response = await fetch('/api/cp/post-problem');
+                setError(null);
+                const response = await fetch(`/api/cp/post-problem?page=${currentPage}&limit=${PAGE_SIZE}`);
 
                 if (!response.ok) {
                     throw new Error('Failed to fetch problems');
@@ -458,6 +467,13 @@ const CPGymPage = () => {
                 const data = await response.json();
 
                 if (data.success && data.problems) {
+                    setPagination({
+                        currentPage: data.currentPage || currentPage,
+                        totalPages: data.totalPages || 0,
+                        totalProblems: data.totalProblems || 0,
+                        pageSize: data.pageSize || PAGE_SIZE
+                    });
+
                     // Map the API response to match the expected format
                     let formattedProblems = data.problems.map(problem => {
                         const postedDate = new Date(problem.postedAt);
@@ -509,7 +525,6 @@ const CPGymPage = () => {
                             } catch (err) {
                                 console.error(`Error fetching rating for ${problem.id}:`, err);
                             }
-                            console.log(problem);
                             return problem;
                         });
 
@@ -581,7 +596,7 @@ const CPGymPage = () => {
                     setUserProgress(prev => ({
                         ...prev,
                         solved: initialSolved,
-                        total: updatedProblems.length
+                        total: data.totalProblems || updatedProblems.length
                     }));
                 }
             } catch (err) {
@@ -594,10 +609,52 @@ const CPGymPage = () => {
 
 
         fetchProblems();
-    }, []);
+    }, [currentPage]);
 
     const [isVerifying, setIsVerifying] = useState({});
 
+    // Pagination helper
+    const DOTS = 'DOTS';
+    const range = (start, end) => {
+        const length = end - start + 1;
+        return Array.from({ length }, (_, idx) => idx + start);
+    };
+
+    const getPaginationRange = ({ currentPage, totalPages, siblingCount = 1 }) => {
+        const totalPageNumbers = siblingCount * 2 + 5; // first, last, current, two siblings, and two dots
+
+        if (totalPages <= totalPageNumbers) {
+            return range(1, totalPages);
+        }
+
+        const leftSiblingIndex = Math.max(currentPage - siblingCount, 1);
+        const rightSiblingIndex = Math.min(currentPage + siblingCount, totalPages);
+
+        const showLeftDots = leftSiblingIndex > 2;
+        const showRightDots = rightSiblingIndex < totalPages - 1;
+
+        const firstPageIndex = 1;
+        const lastPageIndex = totalPages;
+
+        if (!showLeftDots && showRightDots) {
+            const leftItemCount = 3 + 2 * siblingCount;
+            const leftRange = range(1, leftItemCount);
+            return [...leftRange, DOTS, totalPages];
+        }
+
+        if (showLeftDots && !showRightDots) {
+            const rightItemCount = 3 + 2 * siblingCount;
+            const rightRange = range(totalPages - rightItemCount + 1, totalPages);
+            return [firstPageIndex, DOTS, ...rightRange];
+        }
+
+        if (showLeftDots && showRightDots) {
+            const middleRange = range(leftSiblingIndex, rightSiblingIndex);
+            return [firstPageIndex, DOTS, ...middleRange, DOTS, lastPageIndex];
+        }
+
+        return range(1, totalPages);
+    };
     // Convert problem ID from format "2119-B" to "2119B"
     const formatProblemIdForApi = (problemId) => {
         // If the problemId is in format "2119-B", convert to "2119B"
@@ -911,7 +968,7 @@ const CPGymPage = () => {
                                         className={`flex-1 py-4 text-center text-sm font-medium transition-colors flex items-center justify-center ${activeTab === 'problems' ? 'bg-cyan-600 text-white' : 'text-gray-300 hover:bg-gray-800/50'}`}
                                     >
                                         <Code className="w-4 h-4 mr-2" />
-                                        Problems ( Available Problems: {problems.length})
+                                        Problems ( Available Problems: {pagination.totalProblems})
                                     </button>
                                     <div className="h-8 w-px bg-gray-700 my-auto" />
                                     <button
@@ -935,14 +992,61 @@ const CPGymPage = () => {
                             <div className="mt-6">
                                 {activeTab === 'all-submissions' && <AllCFSubmissions />}
                                 {activeTab === 'problems' && (
-                                    <QuestionCf
-                                        problems={problems}
-                                        isVerifying={isVerifying}
-                                        handleVerify={handleVerify}
-                                        openSolverModal={openSolverModal}
-                                        isLoggedIn={!!localStorage.getItem('token')}
-                                        toast={toast}
-                                    />
+                                    <>
+                                        <QuestionCf
+                                            problems={problems}
+                                            isVerifying={isVerifying}
+                                            handleVerify={handleVerify}
+                                            openSolverModal={openSolverModal}
+                                            isLoggedIn={!!localStorage.getItem('token')}
+                                            toast={toast}
+                                        />
+
+                                        {/* Pagination moved to bottom with grey shade */}
+                                        <div className="mt-6 flex justify-center">
+                                            <div className="w-full max-w-3xl rounded-2xl border border-gray-800/40 bg-gray-800/30 px-4 py-3 flex items-center justify-center">
+                                                <nav aria-label="Pagination">
+                                                    <ul className="flex items-center gap-2">
+                                                        <li>
+                                                            <button
+                                                                onClick={() => setCurrentPage(prev => Math.max(prev - 1, 1))}
+                                                                disabled={currentPage === 1 || isLoading}
+                                                                className="rounded-lg border border-gray-700 px-3 py-2 text-sm font-medium text-gray-200 transition-colors hover:bg-gray-800/70 disabled:cursor-not-allowed disabled:opacity-50"
+                                                            >
+                                                                « Previous
+                                                            </button>
+                                                        </li>
+                                                        {getPaginationRange({ currentPage: pagination.currentPage || currentPage, totalPages: Math.max(pagination.totalPages, 1), siblingCount: 1 }).map((pageItem, idx) => (
+                                                            pageItem === DOTS ? (
+                                                                <li key={`dots-${idx}`}>
+                                                                    <span className="px-3 py-2 text-gray-400">...</span>
+                                                                </li>
+                                                            ) : (
+                                                                <li key={`page-${pageItem}`}>
+                                                                    <button
+                                                                        onClick={() => setCurrentPage(pageItem)}
+                                                                        aria-current={pageItem === pagination.currentPage}
+                                                                        className={`px-3 py-2 rounded-lg border text-sm font-medium transition-colors ${pageItem === pagination.currentPage ? 'bg-cyan-600 border-cyan-600 text-white' : 'border-gray-700 text-gray-200 hover:bg-gray-800/70'}`}
+                                                                    >
+                                                                        {pageItem}
+                                                                    </button>
+                                                                </li>
+                                                            )
+                                                        ))}
+                                                        <li>
+                                                            <button
+                                                                onClick={() => setCurrentPage(prev => Math.min(prev + 1, Math.max(pagination.totalPages, 1)))}
+                                                                disabled={currentPage >= pagination.totalPages || pagination.totalPages === 0 || isLoading}
+                                                                className="rounded-lg border border-cyan-700 bg-cyan-600/20 px-3 py-2 text-sm font-medium text-cyan-200 transition-colors hover:bg-cyan-600/30 disabled:cursor-not-allowed disabled:opacity-50"
+                                                            >
+                                                                Next »
+                                                            </button>
+                                                        </li>
+                                                    </ul>
+                                                </nav>
+                                            </div>
+                                        </div>
+                                    </>
                                 )}
 
                                 {activeTab === 'leaderboard' && (


### PR DESCRIPTION
## Summary

Implemented frontend and backend pagination for CP problems to avoid loading all problems at once.

### Changes

* Added server-side pagination using MongoDB skip and limit.
* Added pagination metadata:

  * currentPage
  * totalPages
  * totalProblems
  * pageSize
* Updated CP Gym and Admin Dashboard to fetch paginated data.
* Added Previous/Next pagination controls.
* Ensured only the current page of problems is loaded and rendered.

### Testing

* Verified backend pagination using Postman.
* Tested page 1, page 2, and page 3 responses.
* Confirmed different records are returned for each page.
* Verified frontend requests include page and limit parameters.
* Verified pagination UI works correctly in CP Gym.
* Confirmed only the configured page size of problems is rendered at once.

Fixes the issue where all CP problems were loaded at once, improving page load performance and scalability.
